### PR TITLE
Improve README with dataset info

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,8 @@ python action_detection3.py --model action.h5 --video 0
 ```
 
 Replace `0` with a path to a video file or another webcam index. Add `--output out.mp4` to save the annotated video.
+
+## Dataset
+
+The repository also contains a copy of the [LSA-T](LSA-T) continuous Argentinian Sign Language dataset. See `LSA-T/README.md` for download links and details about the data.
+


### PR DESCRIPTION
## Summary
- document the embedded LSA-T dataset in README

## Testing
- `python -m py_compile action_detection3.py`
- `python action_detection3.py --help` *(fails: No module named 'cv2')*


------
https://chatgpt.com/codex/tasks/task_e_68635362ddd4833183a32a31b1276bdd